### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In this work, we propose an end-to-end framework to learn local multi-view descr
 
 - CUDA \& CUDNN
 
-- Python >= 3.6
+- Python 3.6 or 3.7
 
 - Install packages by
 ```


### PR DESCRIPTION
open3d-python==0.7.0.0 is listed as a requirement, but open3d 0.7.0.0 wasn't released for Python 3.8. See https://github.com/intel-isl/Open3D/releases/tag/v0.7.0